### PR TITLE
feat: userId api

### DIFF
--- a/@types/global.d.ts
+++ b/@types/global.d.ts
@@ -2,11 +2,12 @@ export {};
 
 declare global {
   interface Window {
-    TS: { token: string; url?: string };
-    TSJS: {
-      getUserId: () => string;
-      resetUserId: () => string;
-      setUserId: (id: string) => void;
+    TS: {
+      token: string;
+      url?: string;
+      getUserId?: () => string;
+      resetUserId?: () => string;
+      setUserId?: (id: string) => void;
     };
     testId?: string;
     MozMutationObserver: MutationObserver;

--- a/src/detector.ids.test.ts
+++ b/src/detector.ids.test.ts
@@ -7,19 +7,19 @@ describe("check ids api", () => {
   });
 
   test("generate id", () => {
-    expect(window.TSJS.getUserId()).toMatch(/./);
+    expect(window.TS.getUserId?.()).toMatch(/./);
   });
 
   test("reset id", () => {
-    const userId = window.TSJS.getUserId();
-    window.TSJS.resetUserId();
-    const newUserId = window.TSJS.getUserId();
+    const userId = window.TS.getUserId?.();
+    window.TS.resetUserId?.();
+    const newUserId = window.TS.getUserId?.();
     expect(newUserId).not.toEqual(userId);
     expect(newUserId).toMatch(/./);
   });
 
   test("set custom id", () => {
-    window.TSJS.setUserId("customId");
-    expect(window.TSJS.getUserId()).toEqual("customId");
+    window.TS.setUserId?.("customId");
+    expect(window.TS.getUserId?.()).toEqual("customId");
   });
 });

--- a/src/detector.ts
+++ b/src/detector.ts
@@ -45,11 +45,9 @@ function resetUserId(): string {
   return getUserId();
 }
 
-window.TSJS = {
-  setUserId: setUserIdCookie,
-  getUserId,
-  resetUserId,
-};
+window.TS.setUserId = setUserIdCookie;
+window.TS.getUserId = getUserId;
+window.TS.resetUserId = resetUserId;
 
 // Based on https://stackoverflow.com/a/25490531/1413687
 function getUserIdCookie(): string | undefined {


### PR DESCRIPTION
Now we allow marketplaces to set, reset and retrieve the user id. This will be useful for marketplaces to set user ids according to their own rules and also to fetch the userId for browser generated XHR requests.

Note that as we are storing the user id as a cookie, calls to theiw website will have the tsuid value set.