### PR TITLE
chore: set concurrency in GHA

### DIFF
--- a/.github/workflows/checkpr.yml
+++ b/.github/workflows/checkpr.yml
@@ -7,6 +7,12 @@ on:
       - edited
       - synchronize
 
+# This is to avoid running multiple actions when a PR is updated repeatedly. See
+# https://docs.github.com/en/actions/using-jobs/using-concurrency
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This is to avoid running CI checks for simultaneous builds.