### PR TITLE
fix(test): add test extension to test

### DIFF
--- a/src/detector.clicks-select-child.test.ts
+++ b/src/detector.clicks-select-child.test.ts
@@ -16,21 +16,12 @@ test("check clicks", async () => {
   document.getElementById("non-clickable")?.click();
   expect(events).toHaveLength(1);
 
-  document.getElementById("clickable1")?.click();
   document.getElementById("clickable2")?.click();
 
   const uid = events[0]?.uid;
   expect(events).toMatchObject([
     {
       type: "impression",
-      page: "/",
-      product: "product-id-click-1",
-      auction: "1247eaae-63a1-4c20-9b52-9efdcdef3095",
-      id: expect.stringMatching(/[\d.a-zA-Z-]+/),
-      uid,
-    },
-    {
-      type: "click",
       page: "/",
       product: "product-id-click-1",
       auction: "1247eaae-63a1-4c20-9b52-9efdcdef3095",


### PR DESCRIPTION
The test for child clickable areas was not being run because it was lacking the extension.