### PR TITLE
Change event types to the ones specified in the API

### DIFF
--- a/src/detector.change-attrs.test.ts
+++ b/src/detector.change-attrs.test.ts
@@ -20,7 +20,7 @@ test("change attributes", async () => {
   const uid = events[0]?.uid;
   expect(events).toMatchObject([
     {
-      type: "impression",
+      type: "Impression",
       page: "/",
       product: "product-id-mod-1",
       auction: "1247eaae-63a1-4c20-9b52-9efdcdef3095",
@@ -28,7 +28,7 @@ test("change attributes", async () => {
       uid,
     },
     {
-      type: "impression",
+      type: "Impression",
       page: "/",
       product: "product-id-mod-2",
       auction: undefined,
@@ -45,7 +45,7 @@ test("change attributes", async () => {
   await new Promise(process.nextTick);
   expect(events).toMatchObject([
     {
-      type: "impression",
+      type: "Impression",
       page: "/",
       product: "product-id-mod-1",
       auction: "1247eaae-63a1-4c20-9b52-9efdcdef3095",
@@ -53,7 +53,7 @@ test("change attributes", async () => {
       uid,
     },
     {
-      type: "impression",
+      type: "Impression",
       page: "/",
       product: "product-id-mod-2",
       auction: undefined,

--- a/src/detector.clicks-resolved-bid.test.ts
+++ b/src/detector.clicks-resolved-bid.test.ts
@@ -15,14 +15,14 @@ test("check clicks", async () => {
   const uid = events[0]?.uid;
   expect(events).toMatchObject([
     {
-      type: "impression",
+      type: "Impression",
       page: "/",
       bid: "1212eaae-12a1-4c20-9b52-9efdcdef3095",
       id: expect.stringMatching(/[\d.a-zA-Z-]+/),
       uid,
     },
     {
-      type: "click",
+      type: "ClickEvent",
       page: "/",
       bid: "1212eaae-12a1-4c20-9b52-9efdcdef3095",
       id: expect.stringMatching(/[\d.a-zA-Z-]+/),

--- a/src/detector.clicks-select-child.test.ts
+++ b/src/detector.clicks-select-child.test.ts
@@ -21,7 +21,7 @@ test("check clicks", async () => {
   const uid = events[0]?.uid;
   expect(events).toMatchObject([
     {
-      type: "impression",
+      type: "Impression",
       page: "/",
       product: "product-id-click-1",
       auction: "1247eaae-63a1-4c20-9b52-9efdcdef3095",
@@ -29,7 +29,7 @@ test("check clicks", async () => {
       uid,
     },
     {
-      type: "click",
+      type: "ClickEvent",
       page: "/",
       product: "product-id-click-1",
       auction: "1247eaae-63a1-4c20-9b52-9efdcdef3095",

--- a/src/detector.clicks.test.ts
+++ b/src/detector.clicks.test.ts
@@ -15,7 +15,7 @@ test("check clicks", async () => {
   const uid = events[0]?.uid;
   expect(events).toMatchObject([
     {
-      type: "impression",
+      type: "Impression",
       page: "/",
       product: "product-id-click-1",
       auction: "1247eaae-63a1-4c20-9b52-9efdcdef3095",
@@ -23,7 +23,7 @@ test("check clicks", async () => {
       uid,
     },
     {
-      type: "click",
+      type: "ClickEvent",
       page: "/",
       product: "product-id-click-1",
       auction: "1247eaae-63a1-4c20-9b52-9efdcdef3095",

--- a/src/detector.dynamic.test.ts
+++ b/src/detector.dynamic.test.ts
@@ -15,7 +15,7 @@ test("dynamic content", async () => {
   await new Promise(process.nextTick);
   expect(events).toMatchObject([
     {
-      type: "impression",
+      type: "Impression",
       page: "/",
       product: "product-id-dyn-1",
       auction: "1247eaae-63a1-4c20-9b52-9efdcdef3095",

--- a/src/detector.impressions.test.ts
+++ b/src/detector.impressions.test.ts
@@ -15,7 +15,7 @@ test("check impresssions", async () => {
   const uid = events[0]?.uid;
   expect(events).toMatchObject([
     {
-      type: "impression",
+      type: "Impression",
       page: "/",
       product: "product-id-imp-1",
       auction: undefined,
@@ -23,7 +23,7 @@ test("check impresssions", async () => {
       uid,
     },
     {
-      type: "impression",
+      type: "Impression",
       page: "/",
       product: "product-id-imp-2",
       auction: "1247eaae-63a1-4c20-9b52-9efdcdef3095",

--- a/src/detector.purchases.test.ts
+++ b/src/detector.purchases.test.ts
@@ -13,7 +13,7 @@ test("check purchase", async () => {
 
   expect(events).toMatchObject([
     {
-      type: "purchase",
+      type: "Purchase",
       page: "/",
       product: undefined,
       auction: undefined,

--- a/src/detector.ts
+++ b/src/detector.ts
@@ -65,7 +65,7 @@ function getApiPayload(event: ProductEvent): TopsortEvent {
   };
   const t = new Date(event.t * 1000).toISOString();
   switch (eventType) {
-    case "click":
+    case "ClickEvent":
       return {
         eventType,
         session,
@@ -76,7 +76,7 @@ function getApiPayload(event: ProductEvent): TopsortEvent {
         placement,
         occurredAt: t,
       };
-    case "impression":
+    case "Impression":
       return {
         eventType,
         session,
@@ -91,7 +91,7 @@ function getApiPayload(event: ProductEvent): TopsortEvent {
           },
         ],
       };
-    case "purchase":
+    case "Purchase":
       return {
         eventType,
         session,
@@ -131,7 +131,7 @@ async function processor(data: ProductEvent[]): Promise<ProcessorResult> {
 
 const queue = new Queue(processor);
 
-export type EventType = "click" | "purchase" | "impression";
+export type EventType = "ClickEvent" | "Purchase" | "Impression";
 
 interface Purchase {
   product: string;
@@ -200,7 +200,7 @@ function getEvent(type: EventType, node: HTMLElement): ProductEvent {
     id: generateId(),
     uid: getUserId(),
   };
-  if (type === "purchase") {
+  if (type === "Purchase") {
     event.items = JSON.parse(node.dataset.tsItems || "[]");
   }
   return event;
@@ -212,7 +212,7 @@ function interactionHandler(event: Event): void {
   }
   const container = event.currentTarget.closest(PRODUCT_SELECTOR);
   if (container && container instanceof HTMLElement) {
-    logEvent(getEvent("click", container), container);
+    logEvent(getEvent("ClickEvent", container), container);
   }
 }
 
@@ -233,10 +233,10 @@ function checkChildren(node: Element | Document) {
       continue;
     }
     if (!isPurchase(node)) {
-      logEvent(getEvent("impression", node), node);
+      logEvent(getEvent("Impression", node), node);
       addClickHandler(node);
     } else {
-      logEvent(getEvent("purchase", node), node);
+      logEvent(getEvent("Purchase", node), node);
     }
   }
 }
@@ -268,10 +268,10 @@ function mutationCallback(mutationsList: MutationRecord[]) {
         continue;
       }
       if (!isPurchase(mutation.target)) {
-        logEvent(getEvent("impression", mutation.target), mutation.target);
+        logEvent(getEvent("Impression", mutation.target), mutation.target);
         mutation.target.addEventListener("click", interactionHandler);
       } else {
-        logEvent(getEvent("purchase", mutation.target), mutation.target);
+        logEvent(getEvent("Purchase", mutation.target), mutation.target);
       }
     }
   }

--- a/src/events.ts
+++ b/src/events.ts
@@ -26,14 +26,14 @@ interface Item {
 }
 
 interface ImpressionEvent {
-  eventType: "impression";
+  eventType: "Impression";
   session: Session;
   impressions: Impression[];
   occurredAt: string;
 }
 
 interface ClickEvent {
-  eventType: "click";
+  eventType: "ClickEvent";
   session: Session;
   id: string;
   placement: Placement;
@@ -44,7 +44,7 @@ interface ClickEvent {
 }
 
 interface PurchaseEvent {
-  eventType: "purchase";
+  eventType: "Purchase";
   session: Session;
   id: string;
   purchasedAt: string;


### PR DESCRIPTION
The library cannot communicate with the Topsort backend because it's sending the incorrect event types in the events payload.

## Changes:
- `impressions` ->  `Impressions`
- `click` -> `ClickEvent`
- `purchase` -> `Purchase`

Reported by @twolfvb 