### PR TITLE
feat: allow multiple loads

### DIFF
--- a/@types/global.d.ts
+++ b/@types/global.d.ts
@@ -9,6 +9,7 @@ declare global {
       getUserId?: () => string;
       resetUserId?: () => string;
       setUserId?: (id: string) => void;
+      loaded?: boolean;
     };
     testId?: string;
     MozMutationObserver: MutationObserver;

--- a/src/detector.ts
+++ b/src/detector.ts
@@ -278,6 +278,10 @@ function mutationCallback(mutationsList: MutationRecord[]) {
 }
 
 function start() {
+  if (window.TS?.loaded) {
+    return;
+  }
+  window.TS.loaded = true;
   if (!window.TS?.token) {
     console.error("Missing TS token");
     return;


### PR DESCRIPTION
In the context of Shopify we may end up loading the file multiple times, so in order to prevent the events being reported multime times, we add a check to the library to ensure the library is loaded only once per page.