### PR TITLE
chore(docs): improve readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ npm install @topsort/analytics.js --save
 ### Add markup to your products
 
 ```html
-<div class="product" data-ts-product="<productId>" data-ts-auction="<auctionId>">...</div>
+<div class="product" data-ts-product="<productId>" data-ts-resolved-bid="<resolvedBidId>">...</div>
 ```
 
 Additionally, in case not all the container is clickable (i.e., does not produce an action or does not take you to the product page) or parts of it lead you to a non-related product page, make sure to use the `data-ts-clickable` attribute to indicate what portions of the product should count as a conversion.


### PR DESCRIPTION
The auction id has been deprecated for some time now and we favor the use of the resolved bid id.