### PR TITLE
fix(userId): Prevent the id from resetting on every page refresh

### DIFF
--- a/src/detector.ids.test.ts
+++ b/src/detector.ids.test.ts
@@ -1,8 +1,9 @@
 describe("check ids api", () => {
-  window.TS = {
-    token: "token",
-  };
-  beforeAll(async () => {
+  beforeEach(async () => {
+    window.TS = {
+      token: "token",
+    };
+    jest.resetModules();
     await import("./detector");
   });
 
@@ -20,6 +21,11 @@ describe("check ids api", () => {
 
   test("set custom id", () => {
     window.TS.setUserId?.("customId");
+    expect(window.TS.getUserId?.()).toEqual("customId");
+  });
+
+  test("reads id from cookie correctly", () => {
+    document.cookie = "foo=bar; tsuid=customId";
     expect(window.TS.getUserId?.()).toEqual("customId");
   });
 });

--- a/src/detector.ts
+++ b/src/detector.ts
@@ -55,7 +55,7 @@ window.TS.resetUserId = resetUserId;
 // Based on https://stackoverflow.com/a/25490531/1413687
 function getUserIdCookie(): string | undefined {
   const cookieName = window.TS.cookieName || "tsuid";
-  const regex = new RegExp("/(^|;)\\s*" + cookieName + "\\s*=\\s*([^;]+)/");
+  const regex = new RegExp("(^|;)\\s*" + cookieName + "\\s*=\\s*([^;]+)");
   return regex.exec(document.cookie)?.pop();
 }
 


### PR DESCRIPTION
The `getUserId()` function, when run for the first time, tries to fetch the user id from a cookie, but the current regex is not getting it correctly. This causes the user id to be reset every time the library loads