### PR TITLE
chore: remove engine from packageJson

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,10 +5,6 @@
   "main": "dist/ts.js",
   "type": "module",
   "packageManager": "pnpm@8.6.0",
-  "engines": {
-    "node": ">=18",
-    "pnpm": ">=8"
-  },
   "keywords": [
     "ads",
     "sponsored listings",


### PR DESCRIPTION
The library is pure js so it shouldn't matter the version of node.