### PR TITLE
chore: replace environment variables with `package.json` entries

### DIFF
--- a/.github/workflows/checkpr.yml
+++ b/.github/workflows/checkpr.yml
@@ -31,6 +31,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           cache: pnpm
+          node-version-file: package.json
 
       - name: Install dependencies
         run: pnpm install
@@ -55,6 +56,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           cache: pnpm
+          node-version-file: package.json
 
       - name: Install dependencies
         run: pnpm install

--- a/.github/workflows/checkpr.yml
+++ b/.github/workflows/checkpr.yml
@@ -10,10 +10,6 @@ on:
     branches:
       - main
 
-env:
-  lockfile: pnpm-lock.yaml
-  node_version: "18"
-
 # This is to avoid running multiple actions when a PR is updated repeatedly. See
 # https://docs.github.com/en/actions/using-jobs/using-concurrency
 concurrency:
@@ -34,9 +30,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: ${{ env.node_version }}
           cache: pnpm
-          cache-dependency-path: ${{ env.lockfile }}
 
       - name: Install dependencies
         run: pnpm install
@@ -60,9 +54,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: ${{ env.node_version }}
           cache: pnpm
-          cache-dependency-path: ${{ env.lockfile }}
 
       - name: Install dependencies
         run: pnpm install

--- a/.github/workflows/publish-to-npm.yml
+++ b/.github/workflows/publish-to-npm.yml
@@ -21,6 +21,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           cache: pnpm
+          node-version-file: package.json
 
       - name: Install dependencies
         run: pnpm install

--- a/.github/workflows/publish-to-npm.yml
+++ b/.github/workflows/publish-to-npm.yml
@@ -4,10 +4,6 @@ on:
   release:
     types: [published]
 
-env:
-  lockfile: pnpm-lock.yaml
-  node_version: "18"
-
 jobs:
   npm-publish:
     name: Publish to NPM
@@ -24,9 +20,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: ${{ env.node_version }}
           cache: pnpm
-          cache-dependency-path: ${{ env.lockfile }}
 
       - name: Install dependencies
         run: pnpm install

--- a/package.json
+++ b/package.json
@@ -4,8 +4,11 @@
   "description": "JS library to automatically report events to Topsort's Analytics",
   "main": "dist/ts.js",
   "type": "module",
-  "packageManager": "pnpm@9.1.1",
+  "packageManager": "pnpm@9.9.0",
   "keywords": ["ads", "sponsored listings", "auctions", "analytics", "topsort"],
+  "engines": {
+    "node": ">=20"
+  },
   "exports": {
     ".": {
       "import": "./dist/ts.mjs",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "packageManager": "pnpm@9.9.0",
   "keywords": ["ads", "sponsored listings", "auctions", "analytics", "topsort"],
   "engines": {
-    "node": ">=20"
+    "node": ">=20.0.0"
   },
   "exports": {
     ".": {


### PR DESCRIPTION
According to `actions/node-setup`, it will read `manifest.engine` values to decide what node version to use.
Second, the lockfile path is only relevant if it is non-default.

Refs: https://github.com/actions/setup-node/blob/main/docs/advanced-usage.md#node-version-file