### PR TITLE
fix: don't account for empty attributes

### DIFF
--- a/src/detector.impressions.test.ts
+++ b/src/detector.impressions.test.ts
@@ -34,3 +34,19 @@ test("check impresssions", async () => {
     },
   ]);
 });
+
+test("don\'t consider empty attributes", async () => {
+  window.TS = {
+    token: "token",
+  };
+  const events: any[] = [];
+  window.addEventListener("topsort", (e) => {
+    events.push((e as any).detail);
+  });
+  document.body.innerHTML = `
+    <div data-ts-resolved-bid=""></div>
+  `;
+  await import("./detector");
+
+  expect(events).toMatchObject([]);
+});


### PR DESCRIPTION
> [!Warning]
> This is a work in progress. Do not merge. 

Do not account for empty attributes. Added a test to demostrate that it fires incorrectly.