### PR TITLE
feat: support `vendorId` in purchase events

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Adding further information to purchases can be made by passing the `ts-data-item
 ```html
 <div
   data-ts-action="purchase"
-  data-ts-items='[{"product": "product-id-purchase-1", "quantity":1, "price": 2399}, {"product": "product-id-purchase-2", "quantity": 2, "price": 399}]'
+  data-ts-items='[{"product": "product-id-purchase-1", "quantity":1, "price": 2399}, {"product": "product-id-purchase-2", "quantity": 2, "price": 399, "vendorId": "example-vendor"}]'
 >
   My purchase
 </div>

--- a/src/detector.purchases.test.ts
+++ b/src/detector.purchases.test.ts
@@ -9,7 +9,7 @@ test("check purchase", async () => {
   });
   document.body.innerHTML = `
     <div data-ts-action="purchase" data-ts-items='[{"product":"product-id-purchase1", "price": "2399", "quantity": 1}, {"product":"product-id-purchase2", "price": "299", "quantity": 1}, {"product":"product-id-purchase3", "price": "399", "quantity": 4}]'></div>
-    <div data-ts-action="purchase" data-ts-items='[{"product":"product-id-purchase-after", "price": "2199", "quantity": 1}]'></div>
+    <div data-ts-action="purchase" data-ts-items='[{"product":"product-id-purchase-after", "price": "2199", "quantity": 1, "vendorId": "example-vendor"}]'></div>
   `;
   await import("./detector");
 
@@ -32,7 +32,7 @@ test("check purchase", async () => {
       product: undefined,
       bid: undefined,
       id: expect.stringMatching(/[\d.a-zA-Z-]+/),
-      items: [{ product: "product-id-purchase-after", price: "2199", quantity: 1 }],
+      items: [{ product: "product-id-purchase-after", price: "2199", quantity: 1, vendorId: "example-vendor" }],
     },
   ]);
 });

--- a/src/detector.purchases.test.ts
+++ b/src/detector.purchases.test.ts
@@ -32,7 +32,14 @@ test("check purchase", async () => {
       product: undefined,
       bid: undefined,
       id: expect.stringMatching(/[\d.a-zA-Z-]+/),
-      items: [{ product: "product-id-purchase-after", price: "2199", quantity: 1, vendorId: "example-vendor" }],
+      items: [
+        {
+          product: "product-id-purchase-after",
+          price: "2199",
+          quantity: 1,
+          vendorId: "example-vendor",
+        },
+      ],
     },
   ]);
 });

--- a/src/detector.ts
+++ b/src/detector.ts
@@ -250,23 +250,23 @@ function interactionHandler(event: Event): void {
 
 const intersectionObserver = !!window.IntersectionObserver
   ? new IntersectionObserver(
-    (entries) => {
-      for (const entry of entries) {
-        if (entry.isIntersecting) {
-          const node = entry.target;
-          if (node instanceof HTMLElement) {
-            logEvent(getEvent("Impression", node), node);
-            if (intersectionObserver) {
-              intersectionObserver.unobserve(node);
+      (entries) => {
+        for (const entry of entries) {
+          if (entry.isIntersecting) {
+            const node = entry.target;
+            if (node instanceof HTMLElement) {
+              logEvent(getEvent("Impression", node), node);
+              if (intersectionObserver) {
+                intersectionObserver.unobserve(node);
+              }
             }
           }
         }
-      }
-    },
-    {
-      threshold: INTERSECTION_THRESHOLD,
-    },
-  )
+      },
+      {
+        threshold: INTERSECTION_THRESHOLD,
+      },
+    )
   : undefined;
 
 const PRODUCT_SELECTOR =

--- a/src/detector.ts
+++ b/src/detector.ts
@@ -164,6 +164,7 @@ interface Purchase {
   product: string;
   quantity: number;
   price: number;
+  vendorId?: string;
 }
 
 interface ProductEvent {
@@ -249,23 +250,23 @@ function interactionHandler(event: Event): void {
 
 const intersectionObserver = !!window.IntersectionObserver
   ? new IntersectionObserver(
-      (entries) => {
-        for (const entry of entries) {
-          if (entry.isIntersecting) {
-            const node = entry.target;
-            if (node instanceof HTMLElement) {
-              logEvent(getEvent("Impression", node), node);
-              if (intersectionObserver) {
-                intersectionObserver.unobserve(node);
-              }
+    (entries) => {
+      for (const entry of entries) {
+        if (entry.isIntersecting) {
+          const node = entry.target;
+          if (node instanceof HTMLElement) {
+            logEvent(getEvent("Impression", node), node);
+            if (intersectionObserver) {
+              intersectionObserver.unobserve(node);
             }
           }
         }
-      },
-      {
-        threshold: INTERSECTION_THRESHOLD,
-      },
-    )
+      }
+    },
+    {
+      threshold: INTERSECTION_THRESHOLD,
+    },
+  )
   : undefined;
 
 const PRODUCT_SELECTOR =


### PR DESCRIPTION
Support recieving vendorId in purchases since this is what we generally recommend as part of an integration.