### PR TITLE
fix: skip pnpm publish git branch logic

### DIFF
--- a/.github/workflows/publish-to-npm.yml
+++ b/.github/workflows/publish-to-npm.yml
@@ -44,4 +44,4 @@ jobs:
 
       - name: Publish to npm
         id: publish
-        run: pnpm publish
+        run: pnpm publish --no-git-checks


### PR DESCRIPTION
Otherwise publishing from CI will fail.

Refs: https://github.com/pnpm/pnpm/issues/9011