### PR TITLE
fix: publish directly via npm

### DIFF
--- a/.github/workflows/publish-to-npm.yml
+++ b/.github/workflows/publish-to-npm.yml
@@ -42,6 +42,9 @@ jobs:
       - name: Build dist
         run: pnpm run build
 
+      - name: Update npm
+        run: npm install -g npm@latest
+  
       - name: Publish to npm
         id: publish
-        run: pnpm publish --no-git-checks
+        run: npm publish --no-git-checks


### PR DESCRIPTION
`pnpm` is wrapping `npm` but I fear things are lost in translation since publishing fails with:

```
npm error code ENEEDAUTH
npm error need auth This command requires you to be logged in to https://registry.npmjs.org/

```