### PR TITLE
fix: add repository url to `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "JS library to automatically report events to Topsort's Analytics",
   "main": "dist/ts.js",
   "type": "module",
+  "url": "https://github.com/Topsort/analytics.js",
   "packageManager": "pnpm@9.9.0",
   "keywords": ["ads", "sponsored listings", "auctions", "analytics", "topsort"],
   "engines": {


### PR DESCRIPTION
Required for OIDC publish workflows. Should've probably have been in there either way.