### PR TITLE
chore: release v2.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,22 @@ We follow the format used by [Open Telemetry](https://github.com/open-telemetry/
 
 ## Unreleased
 
+## Version 2.8.0 (2026-04-15)
+
+### Added
+
+- Lazy token loading: events queue when no API token is set and drain automatically when `window.TS.token` is assigned later ([#360](https://github.com/Topsort/analytics.js/pull/360))
+- Interactive playground for testing the analytics library ([#359](https://github.com/Topsort/analytics.js/pull/359))
+
+### Fixed
+
+- Add `lang` attribute to HTML elements for a11y compliance ([#355](https://github.com/Topsort/analytics.js/pull/355))
+- Configure jsdom for Node.js 25+ localStorage compatibility
+
+### Tests
+
+- New queue tests for memory store fallback and error handling ([#358](https://github.com/Topsort/analytics.js/pull/358))
+
 ## Version 2.7.0 (2025-01-23)
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@topsort/analytics.js",
-  "version": "2.7.0",
+  "version": "2.8.0",
   "description": "JS library to automatically report events to Topsort's Analytics",
   "main": "dist/ts.js",
   "type": "module",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -35,6 +35,12 @@ export default defineConfig(({ mode }) => {
     ],
     test: {
       environment: "jsdom",
+      environmentOptions: {
+        jsdom: {
+          url: "http://localhost",
+        },
+      },
+      execArgv: ["--no-experimental-webstorage"],
     },
   };
 });


### PR DESCRIPTION
## Summary
- Bumps version to `2.8.0`
- Fixes jsdom localStorage test failures on Node.js 25+

## Changes since v2.7.0

### Features
- **Lazy token loading** — events queue when no API token is set and drain automatically when `window.TS.token` is assigned later (#360)
- **Interactive playground** — new `/demo` page for testing the analytics library (#359)

### Fixes
- Add `lang` attribute to HTML elements for a11y compliance (#355)
- Configure jsdom for Node 25+ localStorage compatibility (`--no-experimental-webstorage`)

### Tests
- New queue tests for memory store fallback and error handling (#358)

### Housekeeping
- Dependency bumps: biome, react, express, msw, codecov-action, checkout, deploy-pages, upload-pages-artifact, pnpm/action-setup
- Added CLAUDE.md (#354)

## Test plan
- [x] `pnpm run lint:ci` passes
- [x] `pnpm run types:check` passes
- [x] `pnpm run test` — 47/47 tests pass (17 test files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)