### PR TITLE
fix(playground): remove broken UMD fallback and add favicon

### DIFF
--- a/.github/workflows/deploy-playground.yml
+++ b/.github/workflows/deploy-playground.yml
@@ -51,7 +51,6 @@ jobs:
           mkdir -p _site/dist
           cp demo/index.html _site/index.html
           cp dist/ts.iife.js _site/dist/ts.iife.js
-          cp dist/ts.js _site/dist/ts.js
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v4

--- a/demo/index.html
+++ b/demo/index.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="icon" href="data:," />
     <title>analytics.js Playground</title>
     <style>
       *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
@@ -736,15 +737,12 @@
 
         patchFetchForEventApiStatus();
 
-        // Load the analytics.js script
+        // Load the analytics.js IIFE bundle (self-contained, includes @topsort/sdk).
+        // The UMD build (ts.js) cannot work standalone because it treats the SDK as external.
         const script = document.createElement("script");
         script.src = "./dist/ts.iife.js";
         script.onerror = () => {
-          // Fallback: try the UMD build
-          const fallback = document.createElement("script");
-          fallback.src = "./dist/ts.js";
-          fallback.onerror = () => alert("Could not load analytics.js. Run `pnpm run build` first.");
-          document.head.appendChild(fallback);
+          alert("Could not load analytics.js. Make sure the IIFE bundle exists at dist/ts.iife.js (run `pnpm run build`).");
         };
         document.head.appendChild(script);
         analyticsLoaded = true;


### PR DESCRIPTION
## Summary
- Remove the UMD (`ts.js`) fallback from the playground. The UMD build treats `@topsort/sdk` as an external dependency — in a browser without a bundler, `TopsortClient` is `undefined` and all events are silently dropped after detection. Only the IIFE bundle (which inlines the SDK) can work standalone.
- Stop deploying `ts.js` to the playground since it's no longer referenced.
- Add empty `<link rel="icon" href="data:,">` to suppress the favicon 404.

## Root cause
When the IIFE failed to load (e.g., from a stale browser cache of a previous 404), the playground fell back to the UMD build. The UMD loaded and ran — DOM observation, event detection, and the "No API token" warning all worked — but every API call failed silently because the SDK wasn't available, making it look like events weren't firing.

## Test plan
- [x] `pnpm run lint:ci` passes
- [ ] Deploy to GitHub Pages and verify IIFE loads (check devtools Network tab for `ts.iife.js` 200)
- [ ] Verify favicon 404 is gone
- [ ] Add a product element with a token and confirm impression fires

🤖 Generated with [Claude Code](https://claude.com/claude-code)