### PR TITLE
chore(ci): scope NODE_AUTH_TOKEN to npm publish and add --provenance

### DIFF
--- a/.github/workflows/publish-to-npm.yml
+++ b/.github/workflows/publish-to-npm.yml
@@ -27,8 +27,6 @@ jobs:
           cache: pnpm
           node-version-file: package.json
           registry-url: https://registry.npmjs.org
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
 
       - name: Install dependencies
         run: pnpm install
@@ -50,4 +48,6 @@ jobs:
   
       - name: Publish to npm
         id: publish
-        run: npm publish --no-git-checks
+        run: npm publish --no-git-checks --provenance
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}


### PR DESCRIPTION
## Summary

Hardens `.github/workflows/publish-to-npm.yml` to reduce blast radius in case of an install-time supply-chain compromise:

- **Remove `NODE_AUTH_TOKEN` from the `actions/setup-node` step.** It was previously exposed for the entire job, including `pnpm install` (which runs lifecycle scripts), lint, test, and build. Any compromised dependency executing during install could read the npm publish token from `process.env`.
- **Set `NODE_AUTH_TOKEN` only on the `npm publish` step**, which is the sole step that needs it.
- **Add `--provenance` to `npm publish`** so released artifacts get npm package provenance attestations. The job already has `permissions: id-token: write`, so no additional config is needed.

## Context

This is preventive hardening prompted by recent supply-chain incidents (e.g. install-time compromises in transitively-pulled packages). I found no evidence of compromise in this repo — this is purely about reducing future blast radius. The same pattern is being rolled out to `Topsort/banners.js` and `Topsort/topsort.js`.

## Test plan

- [ ] CI lint/test/format jobs pass on the PR (these don't exercise the release workflow).
- [ ] On the next published GitHub Release, confirm the `Release` workflow runs successfully and `npm publish` authenticates correctly.
- [ ] Confirm the published version on npm shows a provenance attestation on the package page.

## Risk

Low. Behavioral diff vs. before:

- The token is no longer present during `pnpm install` / lint / test / build (intended).
- `npm publish` itself still receives the token via `env:` and the `.npmrc` written by `setup-node` (`registry-url` is unchanged), so authentication still works.
- `--provenance` requires `id-token: write` (already set) and a public package on a supported runner (GitHub-hosted `ubuntu-24.04`, OK).

Made with [Cursor](https://cursor.com)